### PR TITLE
add missing docker file for iptables config

### DIFF
--- a/roles/opencontrail/tasks/docker_config.yml
+++ b/roles/opencontrail/tasks/docker_config.yml
@@ -1,4 +1,17 @@
 ---
+- name: Set docker daemon options
+  template:
+    src: docker
+    dest: "/etc/sysconfig/docker-network"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart docker
+  when: ansible_os_family != "CoreOS"
+
+- meta: flush_handlers
+
 - name: Disable usage of iptables by docker
   lineinfile:
     dest: /etc/sysconfig/docker-network

--- a/roles/opencontrail/templates/docker
+++ b/roles/opencontrail/templates/docker
@@ -1,0 +1,2 @@
+# Deployed by Ansible
+DOCKER_NETWORK_OPTIONS=--iptables=false --ip-masq=false


### PR DESCRIPTION
the Kubespray team moved/removed where this file was created so I added it into this task.